### PR TITLE
Add a status server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mysql probe
 
-A golang application that checks a mysql database and creates a series of HTTP responses stored as flat text files that xinetd can return quickly for haproxy health checks.
+A golang application that checks a mysql database, writing results to flat files and/or runs an HTTP server for haproxy health checks based on those checks
 
 ## Installation
 
@@ -22,7 +22,10 @@ GRANT PROCESS,REPLICATION CLIENT ON *.* TO mysql_probe@'%';
 
 ## Running
 
-mysql_probe --help will provide available options.
+````
+$ mysql_probe --help # will provide available commands & flags.
+$ mysql_probe start  # will both test mysql and run the HTTP status server.
+````
 
 ### Checks
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/haikulearning/mysql_probe/mysqltest"
+	"github.com/haikulearning/mysql_probe/statusserver"
 	_ "github.com/go-sql-driver/mysql"
 	"os"
   "log"
@@ -108,7 +109,9 @@ func main() {
       t.Run()
     }()
 
-    log.Println("About to wait")
+    log.Println("Starting status server")
+    statusserver.Run()
+
     wg.Wait()
     log.Println("Finished running")
 	}

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 // The current version of the app
-const VERSION string = "0.0.3"
+const VERSION string = "0.1.0"
 
 func test_mysql(c *cli.Context) {
   log.Println("Testing mysql server")

--- a/main.go
+++ b/main.go
@@ -27,7 +27,8 @@ import (
   "sync"
 )
 
-const VERSION string = "0.0.2"
+// The current versoin of the app
+const VERSION string = "0.0.3"
 
 func main() {
 	// TODO: parse flags

--- a/main.go
+++ b/main.go
@@ -108,8 +108,7 @@ func main() {
 
     if c.Int("server") > 0 {
       log.Println("Starting status server")
-      s := statusserver.NewStatuServer(c.String("reports"), c.Int("server"))
-      s.Start()
+      statusserver.StartStatuServer(c.String("reports"), c.Int("server"))
     }
 
     wg.Wait()

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
   "sync"
 )
 
-// The current versoin of the app
+// The current version of the app
 const VERSION string = "0.0.3"
 
 func main() {
@@ -74,6 +74,12 @@ func main() {
 			EnvVar: "MYSQL_PROBE_REPORTS",
 		},
 		cli.IntFlag{
+			Name:   "server",
+			Value:  3001,
+			Usage:  "port number where the status server should run. Use 0 to disable status server",
+			EnvVar: "MYSQL_PROBE_SERVER",
+		},
+		cli.IntFlag{
 			Name:   "interval, i",
 			Value:  250,
 			Usage:  "interval in milliseconds to run the checks, set to 0 to only run the tests once",
@@ -110,9 +116,11 @@ func main() {
       t.Run()
     }()
 
-    log.Println("Starting status server")
-    s := statusserver.NewStatuServer(c.String("reports"), 3001)
-    s.Start()
+    if c.Int("server") > 0 {
+      log.Println("Starting status server")
+      s := statusserver.NewStatuServer(c.String("reports"), c.Int("server"))
+      s.Start()
+    }
 
     wg.Wait()
     log.Println("Finished running")

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/haikulearning/mysql_probe/mysqltest"
 	"github.com/haikulearning/mysql_probe/statusserver"
@@ -95,15 +94,6 @@ func main() {
 	app.EnableBashCompletion = true
 	app.Action = func(c *cli.Context) {
     log.Println("Started running")
-		// setup checks to run on intervals
-
-		file, err := os.OpenFile(c.String("jsonlog"), os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			panic(fmt.Sprintf("Couldn't open jsonlog \"%s\" for writing: %s", c.String("jsonlog"), err.Error()))
-		}
-		defer file.Close()
-
-		t := mysqltest.NewMysqlTest("connection", c.String("host"), c.Int("port"), c.String("user"), c.String("pass"), c.Int("interval"), c.Int("timeout"), c.String("reports"), file)
 
     var wg sync.WaitGroup
     wg.Add(1)
@@ -112,8 +102,8 @@ func main() {
     go func() {
       // Decrement the counter when the goroutine completes.
       defer wg.Done()
-      // Run our tests
-      t.Run()
+      // Run our mysql tests
+      mysqltest.RunMysqlTest("connection", c.String("host"), c.Int("port"), c.String("user"), c.String("pass"), c.Int("interval"), c.Int("timeout"), c.String("reports"), c.String("jsonlog"))
     }()
 
     if c.Int("server") > 0 {

--- a/main.go
+++ b/main.go
@@ -29,94 +29,138 @@ import (
 // The current version of the app
 const VERSION string = "0.0.3"
 
+func test_mysql(c *cli.Context) {
+  log.Println("Testing mysql server")
+  // Run our mysql tests
+  mysqltest.RunMysqlTest("connection", c.String("host"), c.Int("port"), c.String("user"), c.String("pass"), c.Int("interval"), c.Int("timeout"), c.String("reports"), c.String("jsonlog"))
+}
+
+func serve_status(c *cli.Context) {
+  log.Println("Running status server")
+  // Run our status server
+  statusserver.StartStatuServer(c.String("reports"), c.Int("server_port"))
+}
+
+func test_and_serve(c *cli.Context) {
+  var wg sync.WaitGroup
+
+  wg.Add(1)
+  go func() {
+    // Decrement the counter when the goroutine completes.
+    defer wg.Done()
+    test_mysql(c)
+  }()
+
+  wg.Add(1)
+  go func() {
+    // Decrement the counter when the goroutine completes.
+    defer wg.Done()
+    serve_status(c)
+  }()
+
+  wg.Wait()
+}
+
 func main() {
-	// TODO: parse flags
 	app := cli.NewApp()
 	app.Name = "mysql_probe"
 	app.Usage = "test mysql health and write out http txt responses"
 	app.Version = VERSION
-	app.Flags = []cli.Flag{
+
+  test_mysql_flags := []cli.Flag{
 		cli.StringFlag{
 			Name:   "host",
 			Value:  "127.0.0.1",
-			Usage:  "mysql host to connect to",
+			Usage:  "(test) mysql host to connect to",
 			EnvVar: "MYSQL_PROBE_HOST",
 		},
 		cli.IntFlag{
 			Name:   "port, p",
 			Value:  3306,
-			Usage:  "mysql port to connect to",
+			Usage:  "(test) mysql port to connect to",
 			EnvVar: "MYSQL_PROBE_PORT",
 		},
 		cli.StringFlag{
 			Name:   "user, u",
 			Value:  "root",
-			Usage:  "mysql username to connect with",
+			Usage:  "(test) mysql username to connect with",
 			EnvVar: "MYSQL_PROBE_USER",
 		},
 		cli.StringFlag{
 			Name:   "pass",
 			Value:  "test",
-			Usage:  "mysql password to connect with",
+			Usage:  "(test) mysql password to connect with",
 			EnvVar: "MYSQL_PROBE_PASS",
-		},
-		cli.StringFlag{
-			Name:   "jsonlog",
-			Value:  "/dev/stdout",
-			Usage:  "file to log output in json",
-			EnvVar: "MYSQL_PROBE_JSONLOG",
-		},
-		cli.StringFlag{
-			Name:   "reports",
-			Value:  "tmp",
-			Usage:  "directory to write reports to",
-			EnvVar: "MYSQL_PROBE_REPORTS",
-		},
-		cli.IntFlag{
-			Name:   "server",
-			Value:  3001,
-			Usage:  "port number where the status server should run. Use 0 to disable status server",
-			EnvVar: "MYSQL_PROBE_SERVER",
-		},
-		cli.IntFlag{
-			Name:   "interval, i",
-			Value:  250,
-			Usage:  "interval in milliseconds to run the checks, set to 0 to only run the tests once",
-			EnvVar: "MYSQL_PROBE_INTERVAL",
 		},
 		cli.IntFlag{
 			Name:   "timeout, t",
 			Value:  2000,
-			Usage:  "time in milliseconds to wait for a mysql connection",
+			Usage:  "(test) time in milliseconds to wait for a mysql connection",
 			EnvVar: "MYSQL_PROBE_TIMEOUT",
 		},
-	}
+		cli.IntFlag{
+			Name:   "interval, i",
+			Value:  250,
+			Usage:  "(test) interval in milliseconds to run the checks, set to 0 to only run the tests once",
+			EnvVar: "MYSQL_PROBE_INTERVAL",
+		},
+		cli.StringFlag{
+			Name:   "jsonlog",
+			Value:  "/dev/stdout",
+			Usage:  "(test) file to write test results log output in json",
+			EnvVar: "MYSQL_PROBE_JSONLOG",
+		},
+  }
+  both_flags := []cli.Flag{
+		cli.StringFlag{
+			Name:   "reports",
+			Value:  "tmp",
+			Usage:  "(all) directory for test results up/down status files",
+			EnvVar: "MYSQL_PROBE_REPORTS",
+		},
+  }
+  server_status_flags := []cli.Flag{
+		cli.IntFlag{
+			Name:   "server_port, s",
+			Value:  3001,
+			Usage:  "(serve) port number where the status server accepts requests",
+			EnvVar: "MYSQL_PROBE_SERVER",
+		},
+  }
+
+  all_flags := []cli.Flag{}
+  all_flags = append(all_flags, test_mysql_flags...)
+  all_flags = append(all_flags, both_flags...)
+  all_flags = append(all_flags, server_status_flags...)
+
+  app.Commands = []cli.Command{
+    {
+      Name: "start",
+      Usage: "both test mysql & run a status server of the results",
+      Action: func(c *cli.Context) {
+        test_and_serve(c)
+      },
+      Flags: all_flags,
+    },
+    {
+      Name: "test",
+      Usage: "test a mysql server's status",
+      Action: func(c *cli.Context) {
+        test_mysql(c)
+      },
+      Flags: append(test_mysql_flags, both_flags...),
+    },
+    {
+      Name: "serve",
+      Usage: "run server of the test's output files",
+      Action: func(c *cli.Context) {
+        serve_status(c)
+      },
+      Flags: append(server_status_flags, both_flags...),
+    },
+  }
 	app.EnableBashCompletion = true
-	app.Action = func(c *cli.Context) {
-    log.Println("Started running")
-
-    var wg sync.WaitGroup
-    wg.Add(1)
-
-    log.Println("Started Goroutine")
-    go func() {
-      // Decrement the counter when the goroutine completes.
-      defer wg.Done()
-      // Run our mysql tests
-      mysqltest.RunMysqlTest("connection", c.String("host"), c.Int("port"), c.String("user"), c.String("pass"), c.Int("interval"), c.Int("timeout"), c.String("reports"), c.String("jsonlog"))
-    }()
-
-    if c.Int("server") > 0 {
-      log.Println("Starting status server")
-      statusserver.StartStatuServer(c.String("reports"), c.Int("server"))
-    }
-
-    wg.Wait()
-    log.Println("Finished running")
-	}
 	app.Run(os.Args)
 
-	// TODO: override hard coded config with env vars then cmd line flags
-	// TODO: output logs in logstash json format
 	// TODO: write output files as failures on termination
 }

--- a/main.go
+++ b/main.go
@@ -111,7 +111,8 @@ func main() {
     }()
 
     log.Println("Starting status server")
-    statusserver.Run()
+    s := statusserver.NewStatuServer(c.String("reports"), 3001)
+    s.Start()
 
     wg.Wait()
     log.Println("Finished running")

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func test_and_serve(c *cli.Context) {
 func main() {
 	app := cli.NewApp()
 	app.Name = "mysql_probe"
-	app.Usage = "test mysql health and write out http txt responses"
+	app.Usage = "test mysql health, write the results to disk, and serve them via http"
 	app.Version = VERSION
 
   test_mysql_flags := []cli.Flag{

--- a/mysqltest/mysqlTest.go
+++ b/mysqltest/mysqlTest.go
@@ -20,11 +20,7 @@ import (
 	"database/sql"
 	"fmt"
 	_ "github.com/go-sql-driver/mysql"
-	//"log"
-	//"io"
 	"os"
-	"path/filepath"
-	//"reflect"
 	"errors"
 	"time"
 )
@@ -194,44 +190,6 @@ func (t *MysqlTest) Disconnect() {
 	if t.db != nil {
 		t.db.Close()
 	}
-}
-
-func (t *MysqlTest) WriteTextResult(testname string, status string) {
-	path := fmt.Sprintf("%s.agent.txt", filepath.Join(t.reportdir, "/", testname))
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		//log.Fatal(err)
-		desc := fmt.Sprintf("Couldn't open result file \"%s\": ", err.Error())
-		t.JsonLog(desc)
-		os.Stderr.WriteString(desc)
-		return
-	}
-	defer file.Close()
-	t.JsonLog(fmt.Sprintf("Test: %s result: %s", testname, status))
-	file.WriteString(status)
-}
-
-
-func (t *MysqlTest) WriteHttpResult(testname string, passed bool, description string) {
-	status := "503 Service Unavailable"
-	if passed {
-		status = "200 OK"
-	}
-	now := time.Now().Format(time.RFC1123Z)
-	response := fmt.Sprintf("HTTP/1.1 %s\r\nDate: %s\r\nContent-Type: text/plain\r\n\r\n%s\r\n", status, now, description)
-
-	path := fmt.Sprintf("%s.http.txt", filepath.Join(t.reportdir, "/", testname))
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		//log.Fatal(err)
-		desc := fmt.Sprintf("Couldn't open result file \"%s\": ", err.Error())
-		t.JsonLog(desc)
-		os.Stderr.WriteString(desc)
-		return
-	}
-	defer file.Close()
-	t.JsonLog(fmt.Sprintf("Test: %s result: %v: %s", testname, passed, description))
-	file.WriteString(response)
 }
 
 // NOTE: only works if one master

--- a/mysqltest/mysqlTest.go
+++ b/mysqltest/mysqlTest.go
@@ -18,7 +18,6 @@ package mysqltest
 
 import (
 	"database/sql"
-	//"encoding/json"
 	"fmt"
 	_ "github.com/go-sql-driver/mysql"
 	//"log"
@@ -90,12 +89,6 @@ func (t *MysqlTest) WriteResult(res * MysqlTestResult) {
 // pass it in as a map[string]interface{} and then detect value as int, string, w/e
 // before marshaling json.
 func (t *MysqlTest) JsonLog(msg string) {
-	//t.logger.Println(json.Marshal(t))
-	//buf, err := json.Marshal(v)
-	//if err != nil {
-	//	panic(err)
-	//}
-	//t.jsonlog.Write(buf)
 	t.jsonlog.WriteString(fmt.Sprintf("{\"@timestamp\":\"%s\",\"type\":\"mysql_probe\",\"host\":\"%s\",\"iteration\":%v,\"message\":\"%s\"}\n",
 		time.Now().Format(time.RFC3339), t.host, t.iteration, msg))
 }
@@ -106,10 +99,6 @@ func (t *MysqlTest) GetWeight(val int64, max int64) string {
 	}
 	return fmt.Sprintf("%d%%", 100-(100*(val/max)))
 }
-
-// func writeHttpResult(reportdir string) {
-//
-// }
 
 func (t *MysqlTest) RunOnceWithTimeout() *MysqlTestResult {
   timeout_ch := make(chan *MysqlTestResult, 1)

--- a/mysqltest/mysqlTest.go
+++ b/mysqltest/mysqlTest.go
@@ -35,7 +35,7 @@ var seconds_to_check = []int64{0, 10, 30, 60, 120, 300, 600, 1200, 2400}
 
 type MysqlTest struct {
 	Name          string
-	filedirectory string
+	reportdir     string
 	host          string
 	user          string
 	port          int
@@ -49,8 +49,8 @@ type MysqlTest struct {
 }
 
 
-func NewMysqlTest(name string, host string, port int, user string, pass string, interval int, timeout int, filedirectory string, jsonlog *os.File) *MysqlTest {
-	m := MysqlTest{Name: name, host: host, port: port, user: user, pass: pass, interval: interval, timeout: timeout, filedirectory: filedirectory, jsonlog: jsonlog, iteration: 1}
+func NewMysqlTest(name string, host string, port int, user string, pass string, interval int, timeout int, reportdir string, jsonlog *os.File) *MysqlTest {
+	m := MysqlTest{Name: name, host: host, port: port, user: user, pass: pass, interval: interval, timeout: timeout, reportdir: reportdir, jsonlog: jsonlog, iteration: 1}
 
 	return &m
 }
@@ -98,7 +98,7 @@ func (t *MysqlTest) GetWeight(val int64, max int64) string {
 	return fmt.Sprintf("%d%%", 100-(100*(val/max)))
 }
 
-// func writeHttpResult(filedirectory string) {
+// func writeHttpResult(reportdir string) {
 //
 // }
 
@@ -106,7 +106,7 @@ func (t *MysqlTest) RunOnceWithTimeout() *MysqlTestResult {
   timeout_ch := make(chan *MysqlTestResult, 1)
   ch := make(chan *MysqlTestResult, 1)
 
-  // after 1 second, fill a blank response and 
+  // after 1 second, fill a blank response and
   // send that indicates everything timed out
   go func() {
     time.Sleep(time.Duration(t.timeout) * time.Millisecond)
@@ -199,7 +199,7 @@ func (t *MysqlTest) Disconnect() {
 }
 
 func (t *MysqlTest) WriteTextResult(testname string, status string) {
-	path := fmt.Sprintf("%s.agent.txt", filepath.Join(t.filedirectory, "/", testname))
+	path := fmt.Sprintf("%s.agent.txt", filepath.Join(t.reportdir, "/", testname))
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		//log.Fatal(err)
@@ -222,7 +222,7 @@ func (t *MysqlTest) WriteHttpResult(testname string, passed bool, description st
 	now := time.Now().Format(time.RFC1123Z)
 	response := fmt.Sprintf("HTTP/1.1 %s\r\nDate: %s\r\nContent-Type: text/plain\r\n\r\n%s\r\n", status, now, description)
 
-	path := fmt.Sprintf("%s.http.txt", filepath.Join(t.filedirectory, "/", testname))
+	path := fmt.Sprintf("%s.http.txt", filepath.Join(t.reportdir, "/", testname))
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		//log.Fatal(err)

--- a/mysqltest/mysqlTest.go
+++ b/mysqltest/mysqlTest.go
@@ -51,7 +51,7 @@ type MysqlTest struct {
 
 func RunMysqlTest(name string, host string, port int, user string, pass string, interval int, timeout int, reportdir string, jsonlog string) *MysqlTest {
 
-	jsonlogfile, err := os.OpenFile(jsonlog, os.O_CREATE|os.O_WRONLY, 0644)
+	jsonlogfile, err := os.OpenFile(jsonlog, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't open jsonlog \"%s\" for writing: %s", jsonlog, err.Error()))
 	}

--- a/mysqltest/mysqlTest.go
+++ b/mysqltest/mysqlTest.go
@@ -49,10 +49,19 @@ type MysqlTest struct {
 }
 
 
-func NewMysqlTest(name string, host string, port int, user string, pass string, interval int, timeout int, reportdir string, jsonlog *os.File) *MysqlTest {
-	m := MysqlTest{Name: name, host: host, port: port, user: user, pass: pass, interval: interval, timeout: timeout, reportdir: reportdir, jsonlog: jsonlog, iteration: 1}
+func RunMysqlTest(name string, host string, port int, user string, pass string, interval int, timeout int, reportdir string, jsonlog string) *MysqlTest {
 
-	return &m
+	jsonlogfile, err := os.OpenFile(jsonlog, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't open jsonlog \"%s\" for writing: %s", jsonlog, err.Error()))
+	}
+	defer jsonlogfile.Close()
+
+	m := MysqlTest{Name: name, host: host, port: port, user: user, pass: pass, interval: interval, timeout: timeout, reportdir: reportdir, jsonlog: jsonlogfile, iteration: 1}
+
+	m.Run()
+
+  return &m
 }
 
 func (t *MysqlTest) Run() {

--- a/mysqltest/mysqlTestResult.go
+++ b/mysqltest/mysqlTestResult.go
@@ -1,12 +1,12 @@
 package mysqltest
 
 type MysqlTestResult struct {
-    Entries map[string]string
+  Entries map[string]string
 }
 
-func (r * MysqlTestResult) AddTextResult(subject string, content string) {
-    if r.Entries == nil {
-      r.Entries = make(map[string]string)
-    }
-    r.Entries[subject] = content
+func (r *MysqlTestResult) AddTextResult(subject string, content string) {
+  if r.Entries == nil {
+    r.Entries = make(map[string]string)
+  }
+  r.Entries[subject] = content
 }

--- a/mysqltest/mysqlTestResultWriter.go
+++ b/mysqltest/mysqlTestResultWriter.go
@@ -6,22 +6,35 @@ import (
 	"path/filepath"
 )
 
+type MysqlTestResultWriter struct {
+  test    *MysqlTest
+  result  *MysqlTestResult
+}
+
 func TestResultPath(reportdir string, testname string) string {
   return fmt.Sprintf("%s.agent.txt", filepath.Join(reportdir, "/", testname))
 }
 
-func (t *MysqlTest) WriteTextResult(testname string, status string) {
-	path := TestResultPath(t.reportdir, testname)
+// writes corresponding files for each test result entry
+func (tw *MysqlTestResultWriter) WriteResult() {
+  for k,v := range tw.result.Entries {
+    tw.WriteTextResult(k,v)
+  }
+}
+
+// write an individual test result into to a text file
+func (tw *MysqlTestResultWriter) WriteTextResult(testname string, status string) {
+	path := TestResultPath(tw.test.reportdir, testname)
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		//log.Fatal(err)
 		desc := fmt.Sprintf("Couldn't open result file \"%s\": ", err.Error())
-		t.JsonLog(desc)
+		tw.test.JsonLog(desc)
 		os.Stderr.WriteString(desc)
 		return
 	}
 	defer file.Close()
-	t.JsonLog(fmt.Sprintf("Test: %s result: %s", testname, status))
+	tw.test.JsonLog(fmt.Sprintf("Test: %s result: %s", testname, status))
 	file.WriteString(status)
 }
 
@@ -38,11 +51,11 @@ func (t *MysqlTest) WriteTextResult(testname string, status string) {
 //	if err != nil {
 //		//log.Fatal(err)
 //		desc := fmt.Sprintf("Couldn't open result file \"%s\": ", err.Error())
-//		t.JsonLog(desc)
+//		tw.test.JsonLog(desc)
 //		os.Stderr.WriteString(desc)
 //		return
 //	}
 //	defer file.Close()
-//	t.JsonLog(fmt.Sprintf("Test: %s result: %v: %s", testname, passed, description))
+//	tw.test.JsonLog(fmt.Sprintf("Test: %s result: %v: %s", testname, passed, description))
 //	file.WriteString(response)
 //}

--- a/mysqltest/mysqlTestResultWriter.go
+++ b/mysqltest/mysqlTestResultWriter.go
@@ -1,0 +1,48 @@
+package mysqltest
+
+import (
+  "os"
+	"fmt"
+	"path/filepath"
+)
+
+func TestResultPath(reportdir string, testname string) string {
+  return fmt.Sprintf("%s.agent.txt", filepath.Join(reportdir, "/", testname))
+}
+
+func (t *MysqlTest) WriteTextResult(testname string, status string) {
+	path := TestResultPath(t.reportdir, testname)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		//log.Fatal(err)
+		desc := fmt.Sprintf("Couldn't open result file \"%s\": ", err.Error())
+		t.JsonLog(desc)
+		os.Stderr.WriteString(desc)
+		return
+	}
+	defer file.Close()
+	t.JsonLog(fmt.Sprintf("Test: %s result: %s", testname, status))
+	file.WriteString(status)
+}
+
+//func (t *MysqlTest) WriteHttpResult(testname string, passed bool, description string) {
+//	status := "503 Service Unavailable"
+//	if passed {
+//		status = "200 OK"
+//	}
+//	now := time.Now().Format(time.RFC1123Z)
+//	response := fmt.Sprintf("HTTP/1.1 %s\r\nDate: %s\r\nContent-Type: text/plain\r\n\r\n%s\r\n", status, now, description)
+//
+//	path := fmt.Sprintf("%s.http.txt", filepath.Join(t.reportdir, "/", testname))
+//	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+//	if err != nil {
+//		//log.Fatal(err)
+//		desc := fmt.Sprintf("Couldn't open result file \"%s\": ", err.Error())
+//		t.JsonLog(desc)
+//		os.Stderr.WriteString(desc)
+//		return
+//	}
+//	defer file.Close()
+//	t.JsonLog(fmt.Sprintf("Test: %s result: %v: %s", testname, passed, description))
+//	file.WriteString(response)
+//}

--- a/statusserver/server.go
+++ b/statusserver/server.go
@@ -1,0 +1,44 @@
+package statusserver
+
+import (
+  "fmt"
+  "log"
+  "net/http"
+  "os"
+  "regexp"
+)
+
+func check(e error) {
+    if e != nil {
+        panic(e)
+    }
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+  f, err := os.Open(r.URL.Path[1:])
+  check(err)
+
+  b1 := make([]byte, 10)
+  n1, err := f.Read(b1)
+  check(err)
+
+  match, err := regexp.MatchString("up", string(b1))
+  check(err)
+
+  if match {
+    w.WriteHeader(http.StatusOK)
+    fmt.Fprintf(w, "%s (read %d bytes)\n", string(b1), n1)
+  } else {
+    w.WriteHeader(http.StatusServiceUnavailable)
+    fmt.Fprintf(w, "%s (read %d bytes)\n", string(b1), n1)
+  }
+}
+
+func Run() {
+  http.HandleFunc("/", handler)
+  //fs := http.FileServer(http.Dir("tmp"))
+  //http.Handle("/", fs)
+
+  log.Println("Listening...")
+  http.ListenAndServe(":3000", nil)
+}

--- a/statusserver/server.go
+++ b/statusserver/server.go
@@ -1,6 +1,7 @@
 package statusserver
 
 import (
+  "strconv"
   "fmt"
   "log"
   "net/http"
@@ -8,14 +9,25 @@ import (
   "regexp"
 )
 
+type StatuServer struct {
+	reportdir     string
+	port          int
+}
+
+func NewStatuServer(reportdir string, port int) *StatuServer {
+	s := StatuServer{reportdir: reportdir, port: port}
+
+	return &s
+}
+
 // Start up the status server
-func Start() {
+func (s *StatuServer) Start() {
   http.HandleFunc("/", handler)
   //fs := http.FileServer(http.Dir("tmp"))
   //http.Handle("/", fs)
 
-  log.Println("Listening...")
-  http.ListenAndServe(":3000", nil)
+  log.Println("Listening to port " + strconv.Itoa(s.port))
+  http.ListenAndServe(":" + strconv.Itoa(s.port), nil)
 }
 
 func check(e error) {

--- a/statusserver/server.go
+++ b/statusserver/server.go
@@ -14,8 +14,10 @@ type StatuServer struct {
 	port          int
 }
 
-func NewStatuServer(reportdir string, port int) *StatuServer {
+func StartStatuServer(reportdir string, port int) *StatuServer {
 	s := StatuServer{reportdir: reportdir, port: port}
+
+  s.Start()
 
 	return &s
 }

--- a/statusserver/server.go
+++ b/statusserver/server.go
@@ -8,6 +8,16 @@ import (
   "regexp"
 )
 
+// Start up the status server
+func Start() {
+  http.HandleFunc("/", handler)
+  //fs := http.FileServer(http.Dir("tmp"))
+  //http.Handle("/", fs)
+
+  log.Println("Listening...")
+  http.ListenAndServe(":3000", nil)
+}
+
 func check(e error) {
     if e != nil {
         panic(e)
@@ -32,13 +42,4 @@ func handler(w http.ResponseWriter, r *http.Request) {
     w.WriteHeader(http.StatusServiceUnavailable)
     fmt.Fprintf(w, "%s (read %d bytes)\n", string(b1), n1)
   }
-}
-
-func Run() {
-  http.HandleFunc("/", handler)
-  //fs := http.FileServer(http.Dir("tmp"))
-  //http.Handle("/", fs)
-
-  log.Println("Listening...")
-  http.ListenAndServe(":3000", nil)
 }


### PR DESCRIPTION
Add the ability for `mysql_probe` to serve up HTTP status pages based on its own test results.

Initially the HTTP status server will target [haproxy `option httpchk`](http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#option%20httpchk) configurations, but in the future I hope to add support for [`agent-check`](http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#agent-check) checks too.

This pull also significantly changes the syntax used to run `mysql_probe`:
- `mysql_probe start` - starts testing mysql and runs the HTTP status server
- `mysql_probe test` - only tests mysql
- `mysql_probe serve` - only runs the HTTP status server
