### PR TITLE
Count connections differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-Because this project has not reached 1.0 yet anything may change at any time. The public API should not be considered stable. Still, all breaking changes to the public API will be documented in this file.
+Because this project has not reached 1.0.0 yet anything may change at any time. The public API should not be considered stable. Still, all breaking changes to the public API will be documented in this file.
 
 ## [Unreleased][unreleased]
+### Breaking Changes
+* `connection_count_lte_*` report file will no longer be created. Use `threads_connected_count_lte_*` report files instead (they're functionally equivalent).
+
 ### Added
 * This Change Log!
 * Initial support for cross-compiling via make
@@ -36,7 +39,7 @@ Because this project has not reached 1.0 yet anything may change at any time. Th
 * "Everything!" This was the initial release.
 
 
-[unreleased]: https://github.com/haikulearning/mysql_probe/compare/v0.1.0...master
+[unreleased]: https://github.com/haikulearning/mysql_probe/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/haikulearning/mysql_probe/compare/v0.0.3...v0.1.0
 [0.0.3]: https://github.com/haikulearning/mysql_probe/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/haikulearning/mysql_probe/compare/v0.0.1...v0.0.2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A golang application that checks a mysql database, writing results to flat files and/or runs an HTTP server for haproxy health checks based on those checks
 
+# Requirements
+
+* MySQL >= 5.1.12
+* Access to a MySQL user with REPLICATION CLIENT permissions (or ability to create one)
+
 ## Installation
 
 1. Install golang 1.3+

--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ A golang application that checks a mysql database, writing results to flat files
 ### MySQL configuration
 
 Create a MySQL user with the following permissions:
-* PROCESS
 * REPLICATION CLIENT
 
 For example:
 
 ````sql
-CREATE USER mysql_probe@'%' IDENTIFIED BY 'As92rj05UvKK';
-GRANT PROCESS,REPLICATION CLIENT ON *.* TO mysql_probe@'%';
+CREATE USER 'mysql_probe'@'127.0.0.1' IDENTIFIED BY 'As92rj05UvKK';
+GRANT REPLICATION CLIENT ON *.* TO 'mysql_probe'@'127.0.0.1';
 ````
 
 ## Running

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/haikulearning/mysql_probe/mysqltest"
 	"github.com/haikulearning/mysql_probe/statusserver"
-	_ "github.com/go-sql-driver/mysql"
 	"os"
   "log"
   "sync"

--- a/statusserver/server.go
+++ b/statusserver/server.go
@@ -10,7 +10,7 @@ import (
   "github.com/haikulearning/mysql_probe/mysqltest"
 )
 
-var required_up_checks = []string{"connect", "connection_count_lte_2400"}
+var required_up_checks = []string{"connect", "threads_connected_count_lte_2400"}
 
 type StatuServer struct {
 	reportdir     string


### PR DESCRIPTION
Use the `SESSION_STATUS` table instead of `PROCESSLIST` table because:
1. The `INFORMATION_SCHEMA.SESSION_STATUS` table allows us to get a total count of the number of "Threads Connected" which is equivalent to the previous `SELECT count(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER != 'system user'` query.`
2. The `INFORMATION_SCHEMA.SESSION_STATUS` table lets us get a count of the number of "Threads Running" which gives a slightly more accurate indication of the amount of load the DB is actually recieving from all of its connections.
3. Queries to the `INFORMATION_SCHEMA.SESSION_STATUS` table don't require any additional privilages be granted to the MySQL user running the queries. Granting the `PROCESS` permissions (as was previously required) allows visibility into the contents of MySQL queries being run by all connected MySQL users.
